### PR TITLE
Fix `main` and `module` paths at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "index.umd.cjs",
-  "module": "index.js",
+  "main": "./dist/index.umd.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
These were leading to the wrong location. The `exports` are declared correctly, though, and looks like it is more than enough for Next.js, so this change isn't really neccessary, but still, it is better to have correct paths everywhere