### PR TITLE
Fix "setState during render" warning

### DIFF
--- a/apps/playground-app/src/shared/app/index.ts
+++ b/apps/playground-app/src/shared/app/index.ts
@@ -9,7 +9,7 @@ export const pageStarted = createEvent<{
 
 export const $currentPage = createStore<(typeof pageTypes)[number] | null>(null).on(
   pageStarted,
-  (_, { pageType }) => pageType
+  (_, { pageType }) => pageType ?? "unknown_page"
 );
 
 export function declarePage<Ctx = void>(config: {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build:code": "vite build",
     "build:types": "tsc",
     "build:directive": "node ./scripts/inject-use-client.mjs",
-    "build": "pnpm build:code && pnpm build:types && pnpm build:directive"
+    "build": "pnpm build:code && pnpm build:types && pnpm build:directive",
+    "dev:playground-app": "cd apps/playground-app && pnpm dev"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/src/get-scope.ts
+++ b/src/get-scope.ts
@@ -116,7 +116,19 @@ function HACK_updateScopeRefs(tscope: Scope, values: Values) {
   }
 
   /**
-   * Run scheduled watchers
+   * Delay links run to separate task,
+   * so React won't agro on us for updating state during render
+   */
+  queueMicrotask(() => {
+    HACK_runScopeWatchers(scope, linksToRun);
+  });
+}
+
+function HACK_runScopeWatchers(scope: ScopeInternal, linksToRun: string[]) {
+  /**
+   * Run watchers (`useUnit`, etc) to push new values to them
+   *
+   * Manual lauch is required because top-down re-render stops at `memo`-ed components
    */
   if (linksToRun.length) {
     linksToRun.forEach((nodeId) => {


### PR DESCRIPTION
Delay watchers re-run by one microtask, so React won't be angry at us for calling `setState` during render