### PR TITLE
Fix custom serialize support for newer effector versions

### DIFF
--- a/src/get-scope.browser.test.ts
+++ b/src/get-scope.browser.test.ts
@@ -167,6 +167,7 @@ describe("getClientScope", () => {
            typeof dateStringOrNull === "string" ? new Date(dateStringOrNull) : null,
          write: (dateOrNull) => (dateOrNull ? dateOrNull.toISOString() : null),
         },
+        sid: "test_sid",
     });
 
     const serverScope = fork();

--- a/src/get-scope.browser.test.ts
+++ b/src/get-scope.browser.test.ts
@@ -96,7 +96,7 @@ describe("getClientScope", () => {
   });
   /**
    * Current fix for this test is only implemented inside `effector-react@22.5.4`
-   * 
+   *
    * TODO: After fix is ported into original createWatch of `effector` package in the 23.0.0 release, remove skip
    */
   test.skip("watchers should re-run, if value is changed after server values injection", async () => {
@@ -161,18 +161,23 @@ describe("getClientScope", () => {
   });
 
   test("should support custom serializers", async () => {
-     const $homeDate = createStore<Date | null>(null, {
-        serialize: {
-         read: (dateStringOrNull) =>
-           typeof dateStringOrNull === "string" ? new Date(dateStringOrNull) : null,
-         write: (dateOrNull) => (dateOrNull ? dateOrNull.toISOString() : null),
-        },
-        sid: "test_sid",
+    const $homeDate = createStore<Date | null>(null, {
+      serialize: {
+        read: (dateStringOrNull) =>
+          typeof dateStringOrNull === "string"
+            ? new Date(dateStringOrNull)
+            : null,
+        write: (dateOrNull) => (dateOrNull ? dateOrNull.toISOString() : null),
+      },
+      sid: "test_sid",
     });
 
     const serverScope = fork();
 
-    await allSettled($homeDate, {scope: serverScope, params: new Date(2024, 10, 3) });
+    await allSettled($homeDate, {
+      scope: serverScope,
+      params: new Date(2024, 10, 3),
+    });
 
     const values = serialize(serverScope);
 
@@ -180,9 +185,8 @@ describe("getClientScope", () => {
 
     const clientValue = scope.getState($homeDate);
 
-    console.log(clientValue);
-
     expect(clientValue instanceof Date).toBe(true);
+    expect(clientValue!.getTime()).toEqual(new Date(2024, 10, 3).getTime());
   });
 });
 

--- a/src/get-scope.browser.test.ts
+++ b/src/get-scope.browser.test.ts
@@ -159,6 +159,30 @@ describe("getClientScope", () => {
 
     expect(clientScopeTwo.getState($count)).toEqual(4);
   });
+
+  test("should support custom serializers", async () => {
+     const $homeDate = createStore<Date | null>(null, {
+        serialize: {
+         read: (dateStringOrNull) =>
+           typeof dateStringOrNull === "string" ? new Date(dateStringOrNull) : null,
+         write: (dateOrNull) => (dateOrNull ? dateOrNull.toISOString() : null),
+        },
+    });
+
+    const serverScope = fork();
+
+    await allSettled($homeDate, {scope: serverScope, params: new Date(2024, 10, 3) });
+
+    const values = serialize(serverScope);
+
+    const scope = getScope(values);
+
+    const clientValue = scope.getState($homeDate);
+
+    console.log(clientValue);
+
+    expect(clientValue instanceof Date).toBe(true);
+  });
 });
 
 describe("getScope implementation details", () => {

--- a/src/get-scope.ts
+++ b/src/get-scope.ts
@@ -75,6 +75,11 @@ function INTERNAL_getClientScope(values?: Values) {
 function HACK_injectValues(scope: Scope, values: Values) {
   // @ts-expect-error this is a really hacky way to "hydrate" scope
   Object.assign(scope.values.sidMap, values);
+  /**
+   * We should explicitly set this flag to true, because otherwise the scope will be treated as it was not created from serialized values
+   * => effector will not apply custom serializers to the scope
+   */
+  (scope as any).fromSerialize = true;
 }
 
 function HACK_updateScopeRefs(tscope: Scope, values: Values) {


### PR DESCRIPTION
Fixes #35 

This case was broken after release of effector 23.0.0, as it came with other kernel optimizations

